### PR TITLE
Fix redoc missing brand logo

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -46,7 +46,7 @@ configure :build do
   # rewrite_ignore does not work as it conflicts weirdly with relative_assets. Disabling
   # the .woff2 extension only does not work as .woff will still activate it so have to
   # have both. See https://github.com/slatedocs/slate/issues/1171 for more details.
-  activate :asset_hash, :exts => app.config[:asset_extensions] - %w[.woff .woff2]
+  activate :asset_hash, :exts => app.config[:asset_extensions] - %w[.woff .woff2 .png .jpg]
   # If you're having trouble with Middleman hanging, commenting
   # out the following two lines has been known to help
   activate :minify_css


### PR DESCRIPTION
Slate automates cache-busting on deployment by appending hashes to the end of all of your static assets and changing your links to reference the new names. However, redoc is searching for a file with a hard-coded name when attempting to retrieve our logo, causing it to currently not display:

https://developer.code42.com/sandbox/api/

This fixes the issue by opting images out of the hashing functionality.