### PR TITLE
update redoc to fix slash bug

### DIFF
--- a/source/layouts/api-docs-layout.erb
+++ b/source/layouts/api-docs-layout.erb
@@ -12,7 +12,7 @@
   <body>
     <%= partial(:top_nav) %>
     <div id="redoc-container"></div>
-    <script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-rc.40/bundles/redoc.standalone.js"> </script>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-rc.48/bundles/redoc.standalone.js"> </script>
     <script>
         var opts = {
             hideHostname: true,


### PR DESCRIPTION
* Updates Redoc to make use of a bug fix that removes the extra leading slash for copying the swagger paths.