### PR TITLE
fix auth examples

### DIFF
--- a/source/intro-to-developer-portal/index.html.md
+++ b/source/intro-to-developer-portal/index.html.md
@@ -40,7 +40,7 @@ Combine the [request URL](#request-urls) with the resource to get the full URL f
 For example, the [Auth API documentation](/api/#tag/Auth) shows the resource as `/v1/auth/`. To run the Auth API, combine the request URL with the resource in the API call:
 
 ```bash
-curl -X GET -u "username" -H "Accept: application/json" "https://api.us.code42.com/v1/auth/basic?useBody=true"
+curl -X GET -u "username" -H "Accept: application/json" "https://api.us.code42.com/v1/auth/"
 ```
 
 ## Authentication
@@ -50,13 +50,13 @@ Most API calls require an [authentication token](https://support.code42.com/Admi
 In the following example, replace `<Code42Username>` with a Code42 administrator username, and replace `<RequestURL>` with the [request URL](#request-urls) of your Code42 cloud instance:
 
 ```bash
-curl -X GET -u "<Code42Username>" -H "Accept: application/json" "https://<RequestURL>/v1/auth/basic?useBody=true"
+curl -X GET -u "<Code42Username>" -H "Accept: application/json" "https://<RequestURL>/v1/auth/"
 ```
 
 If your organization uses [two-factor authentication for local users](https://support.code42.com/Administrator/Cloud/Configuring/Two-factor_authentication_for_local_users), you must also include a `totp-auth` header value containing the Time-based One-Time Password (TOTP) supplied by the Google Authenticator mobile app. The example below includes a TOTP value of 424242.
 
 ```bash
-curl -X GET -u "<Code42Username>" -H "totp-auth: 424242" "Accept: application/json" "https://<RequestURL>/v1/auth/basic?useBody=true"
+curl -X GET -u "<Code42Username>" -H "totp-auth: 424242" "Accept: application/json" "https://<RequestURL>/v1/auth/"
 ```
 
 A successful request returns an authentication token. For example:


### PR DESCRIPTION
examples were still using the old `/auth/basic` path.