### PR TITLE
pin ubuntu os version for builds

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     env:
         ruby-version: 2.5
     steps:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     env:
         ruby-version: 2.5
     steps:


### PR DESCRIPTION
Developer portal nightly build started failing recently, even though there were no changes to the codebase:
https://github.com/code42/developer.code42.com/actions/runs/538872811

I suspect this is is because GitHub recently changed the default version of Ubuntu container that is used for building when the tag `ubuntu-latest` is changed:

https://github.com/actions/virtual-environments/issues/1816

Looking at the build output history confirms that the last successful run used ubuntu 18 while the failing runs use ubuntu 20.