### PR TITLE
add gov cloud api domain to getting started guide

### DIFF
--- a/source/api/getting_started.rmd
+++ b/source/api/getting_started.rmd
@@ -9,6 +9,7 @@ The domain used for making API requests can be determined using the domain you u
 | crashplan.com          | api.prod.ffs.us2.code42.com |
 | console.us.code42.com  | api.us.code42.com           |
 | console.ie.code42.com  | api.ie.code42.com           |
+| console.gov.code42.com | api.gov.code42.com          |
 
 ## Authentication
 


### PR DESCRIPTION
Show which domain is used to call the gov cloud API now that it's live.