### PR TITLE
Update getting_started.rmd per LAMA URL change

### DIFF
--- a/source/api/getting_started.rmd
+++ b/source/api/getting_started.rmd
@@ -4,12 +4,12 @@
 
 The domain used for making API requests can be determined using the domain you use to log in to the Code42 console. All API requests should be made using https.
 
-| Console Domain         | API Domain         |
-| ---------------------- | ------------------ |
-| crashplan.com          | api.us2.code42.com |
-| console.us.code42.com  | api.us.code42.com  |
-| console.ie.code42.com  | api.ie.code42.com  |
-| console.gov.code42.com | api.gov.code42.com |
+| Console Domain            | API Domain         |
+| ------------------------- | ------------------ |
+| console.us.code42.com     | api.us.code42.com  |
+| console.us2.crashplan.com | api.us2.code42.com |
+| console.ie.code42.com     | api.ie.code42.com  |
+| console.gov.code42.com    | api.gov.code42.com |
 
 ## Authentication
 


### PR DESCRIPTION
Under "Request URLs" changed "crashplan.com" to "console.us2.crashplan.com" in accordance with LAMA changes made on August 3, 2021.