### PR TITLE
Update getting_started.rmd

### DIFF
--- a/source/api/getting_started.rmd
+++ b/source/api/getting_started.rmd
@@ -61,12 +61,6 @@ curl -u "<username>:<password>" https://<RequestURL>/<Resource>
 curl -X GET -u "<username>:<password>" https://<RequestURL>/v1/auth
 ```
 
-**Basic authentication to obtain a User authentication token with the auth/jwt method:**
-
-```bash
-curl -u "<username>:<password>"  https://<RequestURL>/c42api/v3/auth/jwt?useBody=true
-```
-
 **Basic authentication to obtain a User authentication token when a second factor (TOTP) token is required:**
 
 ```bash


### PR DESCRIPTION
Removed the following text from the Authentication section of Getting Started. We're removing it because this page in the developer portal should be limited in scope to the API gateway and not other ways of accessing the API:

Basic authentication to obtain a User authentication token with the auth/jwt method:
curl -u "<username>:<password>"  https://<RequestURL>/c42api/v3/auth/jwt?useBody=true