### PR TITLE
Updates to deploy trusted-activity v2 api docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ API_DOCS = $(BUILD)/api
 DOCS_SERVER = "https://api.us.code42.com"
 BUILD_SCRIPTS = build-scripts
 
-all:: clean html locations download definitions unify
+all:: clean html locations download transform definitions unify
 
 run:: all serve
 
@@ -18,6 +18,9 @@ locations::
 
 download::
 	$(BUILD_SCRIPTS)/download_open_api_files.sh $(DOCS_SRC) $(DOCS)
+
+transform::
+	$(BUILD_SCRIPTS)/transform.sh $(DOCS)
 
 definitions::
 	$(BUILD_SCRIPTS)/extract_open_api_paths_and_definitions.sh $(DOCS) $(DOCS_SRC)
@@ -31,4 +34,4 @@ html::
 serve::
 	bundle exec middleman serve
 
-.PHONY:: all clean locations download definitions unify html serve
+.PHONY:: all clean locations download transform definitions unify html serve

--- a/build-scripts/get_open_api_file_locations.sh
+++ b/build-scripts/get_open_api_file_locations.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 main () {
   local docs_server="${1:?Missing param docs_server at index 1.}"
   local docs_src="${2:?Missing param docs_src at index 2.}"
-  local docs_endpoints=$(curl -sS --fail ${docs_server}/api/docs-index/v1 | jq -r .services[].location)
+  local docs_endpoints=$(curl -sS --fail ${docs_server}/api/docs-index | jq -r .services[].location)
   printf "%s\n" "${docs_endpoints}" > ${docs_src}/docs_endpoints.txt
   sed -i -e "s~^~${docs_server}~" ${docs_src}/docs_endpoints.txt
 }

--- a/build-scripts/transform.sh
+++ b/build-scripts/transform.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+main() {
+  local docs="${1:?Missing param docs at index 1.}"
+  echo "Applying transformations..."
+  # mark trusted-activities summary fields with "v1" and "v2" accordingly
+  jq '.paths[][].summary |= "v1 - \(.)"' < ${docs}/trusted-activities > ${docs}/transform.tmp && mv ${docs}/transform.tmp ${docs}/trusted-activities
+  jq '.paths[][].summary |= "v2 - \(.)"' < ${docs}/trusted-activities.json > ${docs}/transform.tmp && mv ${docs}/transform.tmp ${docs}/trusted-activities.json
+  # mark trusted-activities v1 endpoints as deprecated
+  jq '.paths[][].deprecated = true' < ${docs}/trusted-activities > ${docs}/transform.tmp && mv ${docs}/transform.tmp ${docs}/trusted-activities
+}
+
+main "$@"


### PR DESCRIPTION
Since trusted-activity is adding a v2 endpoint, we need to get all versions from the gateway