### PR TITLE
Chore: add v2 file-event endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,7 @@ make serve
 ```
 
 Then, open your browser to `localhost:4567` to explore the site. Once the server is started, you can edit files and simply refresh the page to see your changes!
+
+## Development with a local Baldur instance
+The dev portal can build docs from a locally running Baldur instance by modifying the DOCS_SERVER variable in the Makefile to the url of your local Baldur.
+By default, that is `http://localhost:5000`

--- a/build-scripts/transform.sh
+++ b/build-scripts/transform.sh
@@ -31,7 +31,7 @@ main() {
   jq '.paths |= with_entries( if .key | contains("v1") then .value[].deprecated |= true else . end)' < $FILE_EVENTS > $TMP && mv $TMP $FILE_EVENTS
 
    # prefix v2 summary fields with "v2"
-  jq '.paths |= with_entries( if .key | contains("v2") then .value.post.summary  |= "v2 - \(.)" else . end)' < $FILE_EVENTS > $TMP && mv $TMP $FILE_EVENTS
+  jq '.paths |= with_entries( if .key | contains("v2") then (if .value.post? then .value.post.summary |= "v2 - \(.)" else .value.get.summary |= "v2 - \(.)" end) else . end)' < $FILE_EVENTS > $TMP && mv $TMP $FILE_EVENTS
 
   ### Watchlists
   # convert openapi 3 yaml to swagger 2 json

--- a/build-scripts/transform.sh
+++ b/build-scripts/transform.sh
@@ -6,6 +6,7 @@ main() {
   TRUSTED_ACTIVITIES_V1="${docs}/trusted-activities"
   TRUSTED_ACTIVITIES_V2="${docs}/trusted-activities.json"
   WATCHLISTS="${docs}/watchlists.json"
+  FILE_EVENTS="${docs}/file-events"
 
   echo "Applying transformations..."
 
@@ -23,6 +24,14 @@ main() {
   jq '.paths[][].tags |= [ "Trusted Activities" ]' < $TRUSTED_ACTIVITIES_V2 > $TMP && mv $TMP $TRUSTED_ACTIVITIES_V2
   # mark trusted-activities summary fields with "v1" and "v2" accordingly
   jq '.paths[][].summary |= "v2 - \(.)"' < $TRUSTED_ACTIVITIES_V2 > $TMP && mv $TMP $TRUSTED_ACTIVITIES_V2
+
+  ### File Events
+  # prefix v1 summary fields with "v1" and mark as deprecated
+  jq '.paths |= with_entries( if .key | contains("v1") then .value[].summary  |= "v1 - \(.)" else . end)' < $FILE_EVENTS > $TMP && mv $TMP $FILE_EVENTS
+  jq '.paths |= with_entries( if .key | contains("v1") then .value[].deprecated |= true else . end)' < $FILE_EVENTS > $TMP && mv $TMP $FILE_EVENTS
+
+   # prefix v2 summary fields with "v2"
+  jq '.paths |= with_entries( if .key | contains("v2") then .value.post.summary  |= "v2 - \(.)" else . end)' < $FILE_EVENTS > $TMP && mv $TMP $FILE_EVENTS
 
   ### Watchlists
   # convert openapi 3 yaml to swagger 2 json


### PR DESCRIPTION
<img width="335" alt="Screen Shot 2022-04-12 at 10 28 58 AM" src="https://user-images.githubusercontent.com/34320012/163011381-ab151a41-804e-45c6-9619-459c794e1658.png">
This PR will have to sit until the saved-search v2 apis are released. Nothing should have to change in this PR, but we want the v2 saved search passthrough to be available before releasing this