### PR TITLE
don't delete source yaml files to make testing changes locally easier

### DIFF
--- a/build-scripts/extract_open_api_paths_and_definitions.sh
+++ b/build-scripts/extract_open_api_paths_and_definitions.sh
@@ -5,8 +5,9 @@ set -euo pipefail
 main() {
   local docs="${1:?Missing param docs at index 1.}"
   local docs_src="${2:?Missing param docs_src at index 2.}"
-  jq -s '.[].paths' ${docs}/* | jq -s add > ${docs_src}/paths.json
-  jq -s '.[].definitions' ${docs}/* | jq -s add > ${docs_src}/defs.json
+  json_docs=$(find ${docs} \! -name '*.yaml' -type f)
+  jq -s '.[].paths' $json_docs | jq -s add > ${docs_src}/paths.json
+  jq -s '.[].definitions' $json_docs | jq -s add > ${docs_src}/defs.json
 }
 
 main "$@"

--- a/build-scripts/transform.sh
+++ b/build-scripts/transform.sh
@@ -18,7 +18,6 @@ main() {
   ### Trusted Activities v2
   # convert openapi 3 yaml to swagger 2 json
   api-spec-converter -f openapi_3 -t swagger_2 -c ${docs}/trusted-activities.yaml > $TRUSTED_ACTIVITIES_V2
-  rm ${docs}/trusted-activities.yaml
   # rename tags
   jq '.paths[][].tags |= [ "Trusted Activities" ]' < $TRUSTED_ACTIVITIES_V2 > $TMP && mv $TMP $TRUSTED_ACTIVITIES_V2
   # mark trusted-activities summary fields with "v1" and "v2" accordingly
@@ -27,7 +26,6 @@ main() {
   ### Watchlists
   # convert openapi 3 yaml to swagger 2 json
   api-spec-converter -f openapi_3 -t swagger_2 -c ${docs}/watchlists.yaml > $WATCHLISTS
-  rm ${docs}/watchlists.yaml
   # rename UserRiskProfileService tags
   jq '(.paths[][] | select(.tags == ["UserRiskProfileService"]) | .tags) |= ["User Risk Profiles"]' < $WATCHLISTS > $TMP && mv $TMP $WATCHLISTS
   # rename WatchlistsService tags


### PR DESCRIPTION
This enables us to download the existing source files once via `make locations download` then edit the .yaml files and test changes locally by running `make transform definitions unify html serve` (to skip re-downloading). Otherwise local changes would get wiped out by the deletion of the .yaml sources.