### PR TITLE
Update file_events.rmd

### DIFF
--- a/source/api/api-descriptions/file_events.rmd
+++ b/source/api/api-descriptions/file_events.rmd
@@ -2,7 +2,7 @@ To use these endpoints, your [product plan](https://code42.com/r/support/product
 
 File events represent the creation, modification, deletion, and movement of files in your organization's working environment (both on endpoints and in supported cloud providers).
 
-When file activity occurs on an endpoint or in the cloud, Incydr records metadata about the event and retains it for 90 days. At any time in that 90-day window you can search for the file activity based on the metadata collected, such as (but not limited to):
+When file activity occurs on an endpoint or in the cloud, Incydr records metadata about the event and retains it according to the event data retention period specified in your product plan. At any time during that retention period, you can search for the file activity based on the metadata collected, such as (but not limited to):
 
 - the file name
 - who acted on the file


### PR DESCRIPTION
File event metadata is no longer retained for 90 days for all customers like it used to be. It's now based on their product plan and currently can range from 30 - 180 days.