### PR TITLE
Update alerts.rmd

### DIFF
--- a/source/api/api-descriptions/alerts.rmd
+++ b/source/api/api-descriptions/alerts.rmd
@@ -1,5 +1,2 @@
 Alerts are notifications that are produced when user file activity matches one or more alert rules. To create alert rules using the API, see the [Rules APIs](/api#tag/Rules).
 When an alert is triggered, it appears on the [Alerts > Review Alerts](https://support.code42.com/Administrator/Cloud/Code42_console_reference/Alerts_reference#Review_Alerts) screen in the Code42 console, and if configured, an email is sent to an administrator.
-
-For more information about the Rules and Alerts APIs, see our [Security alerts API](/security-alerts-api/#security-alerts-api) guide.
-


### PR DESCRIPTION
Removed a sentence containing a broken link to the Alerts user guide. Removed the entire sentence because we don't need to link to the Alerts user guide from the Alerts resource documentation.