### PR TITLE
Update rules.rmd

### DIFF
--- a/source/api/api-descriptions/rules.rmd
+++ b/source/api/api-descriptions/rules.rmd
@@ -1,4 +1,2 @@
 Rules define criteria for what types of file activity should result in alerts, and who will be alerted when important data may be leaving your company.
 In addition to being able to create your own custom rules, Incydr provides [default rules](https://support.code42.com/Administrator/Cloud/Monitoring_and_managing/How_to_create_a_security_alert#Default_alert_rules_and_notifications) that are applied to users in [Detection Lists](/api#tag/Detection-Lists).
-
-For more information about the rules and alerts APIs, see our [Security alerts API](/security-alerts-api/#security-alerts-api) article.


### PR DESCRIPTION
Removed a sentence containing a broken link to the Alerts user guide. Removed the entire sentence because we don't need to link to the Alerts user guide from the Rules resource documentation.