### PR TITLE
Chore/update transform script for watchlists docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ DOCS = $(DOCS_SRC)/docs
 DOCS_OUT = $(DOCS_SRC)/out
 API_DOCS = $(BUILD)/api
 DOCS_SERVER = "https://api.us.code42.com"
+#DOCS_SERVER = "http://localhost:5000" # Use this value as the docserver for a locally hosted baldur instance
 BUILD_SCRIPTS = build-scripts
 
 all:: clean docs html locations download transform definitions unify

--- a/build-scripts/transform.sh
+++ b/build-scripts/transform.sh
@@ -7,7 +7,6 @@ main() {
   RULES_V1="${docs}/alert-rules"
   RULES_V2="${docs}/alert-rules-v2"
   TRUSTED_ACTIVITIES_V2="${docs}/trusted-activities.json"
-  WATCHLISTS="${docs}/watchlists.json"
   FILE_EVENTS="${docs}/file-events.json"
   CASES="${docs}/cases.json"
   ACTORS="${docs}/actors.json"
@@ -20,10 +19,9 @@ main() {
   jq '.paths[][].tags |= [ "Audit Log" ]' < ${docs}/audit > $TMP && mv $TMP ${docs}/audit
 
   ### Trusted Activities v2
-  # Remove static TA v2 docs until we can swap over baldur
-  rm "${docs}/trusted-activities.yaml"
   # convert openapi 3 yaml to swagger 2 json
   api-spec-converter -f openapi_3 -t swagger_2 -c ${docs}/trusted-activities > $TRUSTED_ACTIVITIES_V2
+  rm "${docs}/trusted-activities"
 
   ### File Events
   api-spec-converter -f openapi_3 -t swagger_2 -c ${docs}/file-events > $FILE_EVENTS
@@ -57,20 +55,25 @@ main() {
   jq 'del(.paths."/v2/alert-rules/{id}/remove-user-aliases")' < $RULES_V2 > $TMP && mv $TMP $RULES_V2
 
   ### Watchlists
+  WATCHLISTS="${docs}/watchlists.json"
   # convert openapi 3 yaml to swagger 2 json
-  api-spec-converter -f openapi_3 -t swagger_2 -c ${docs}/watchlists.yaml > $WATCHLISTS
-  # rename tags
-  jq '.paths[][].tags[] |=
-  if . == "WatchlistService" then "Watchlists"
-  elif . == "UserRiskProfileService" then "User Risk Profiles"
-  elif . == "DepartmentsService" then "Departments"
-  elif . == "DirectoryGroupsService" then "Directory Groups"
-  else .
-  end' < $WATCHLISTS > $TMP && mv $TMP $WATCHLISTS
+  api-spec-converter -f openapi_3 -t swagger_2 -c ${docs}/departments-v1 > "${docs}/departments-v1.json"
+  rm ${docs}/departments-v1
+  api-spec-converter -f openapi_3 -t swagger_2 -c ${docs}/directory-groups-v1 > "${docs}/directory-groups-v1.json"
+  rm ${docs}/directory-groups-v1
+  api-spec-converter -f openapi_3 -t swagger_2 -c ${docs}/watchlists-v1 > "${docs}/watchlists-v1.json"
+  rm ${docs}/watchlists-v1
+  api-spec-converter -f openapi_3 -t swagger_2 -c ${docs}/watchlists-v2 > "${docs}/watchlists-v2.json"
+  rm ${docs}/watchlists-v2
+  api-spec-converter -f openapi_3 -t swagger_2 -c ${docs}/risk-profiles-v1 > "${docs}/risk-profiles-v1.json"
+  rm ${docs}/risk-profiles-v1
+  api-spec-converter -f openapi_3 -t swagger_2 -c ${docs}/risk-profiles-v2 > "${docs}/risk-profiles-v2.json"
+  rm ${docs}/risk-profiles-v2
+
   # set update-risk-profile PATCH description
-  jq '.paths[][] |=
-  if .operationId == "UpdateUserRiskProfile" then .description = {"$ref": "./api-descriptions/user_risk_profile_patch.rmd"}
-  else . end' < $WATCHLISTS > $TMP && mv $TMP $WATCHLISTS
+#  jq '.paths[][] |=
+#  if .operationId == "UpdateUserRiskProfile" then .description = {"$ref": "./api-descriptions/user_risk_profile_patch.rmd"}
+#  else . end' < $WATCHLISTS > $TMP && mv $TMP $WATCHLISTS
 
   ### Cases
   # convert openapi 3 yaml to swagger 2 json

--- a/build-scripts/transform.sh
+++ b/build-scripts/transform.sh
@@ -55,25 +55,18 @@ main() {
   jq 'del(.paths."/v2/alert-rules/{id}/remove-user-aliases")' < $RULES_V2 > $TMP && mv $TMP $RULES_V2
 
   ### Watchlists
-  WATCHLISTS="${docs}/watchlists.json"
   # convert openapi 3 yaml to swagger 2 json
-  api-spec-converter -f openapi_3 -t swagger_2 -c ${docs}/departments-v1 > "${docs}/departments-v1.json"
-  rm ${docs}/departments-v1
-  api-spec-converter -f openapi_3 -t swagger_2 -c ${docs}/directory-groups-v1 > "${docs}/directory-groups-v1.json"
-  rm ${docs}/directory-groups-v1
-  api-spec-converter -f openapi_3 -t swagger_2 -c ${docs}/watchlists-v1 > "${docs}/watchlists-v1.json"
-  rm ${docs}/watchlists-v1
-  api-spec-converter -f openapi_3 -t swagger_2 -c ${docs}/watchlists-v2 > "${docs}/watchlists-v2.json"
-  rm ${docs}/watchlists-v2
-  api-spec-converter -f openapi_3 -t swagger_2 -c ${docs}/risk-profiles-v1 > "${docs}/risk-profiles-v1.json"
-  rm ${docs}/risk-profiles-v1
-  api-spec-converter -f openapi_3 -t swagger_2 -c ${docs}/risk-profiles-v2 > "${docs}/risk-profiles-v2.json"
-  rm ${docs}/risk-profiles-v2
+  api-spec-converter -f openapi_3 -t swagger_2 -c ${docs}/departments > "${docs}/departments.json"
+  rm ${docs}/departments
+  api-spec-converter -f openapi_3 -t swagger_2 -c ${docs}/directory-groups > "${docs}/directory-groups.json"
+  rm ${docs}/directory-groups
+  api-spec-converter -f openapi_3 -t swagger_2 -c ${docs}/watchlists > "${docs}/watchlists.json"
+  rm ${docs}/watchlists
+  api-spec-converter -f openapi_3 -t swagger_2 -c ${docs}/risk-profiles > "${docs}/risk-profiles.json"
+  rm ${docs}/risk-profiles
 
   # set update-risk-profile PATCH description
-#  jq '.paths[][] |=
-#  if .operationId == "UpdateUserRiskProfile" then .description = {"$ref": "./api-descriptions/user_risk_profile_patch.rmd"}
-#  else . end' < $WATCHLISTS > $TMP && mv $TMP $WATCHLISTS
+  jq '.paths."/v2/actor-risk-profiles/{actor_id}".patch.description |= {"$ref": "./api-descriptions/user_risk_profile_patch.rmd"}' < "${docs}/risk-profiles.json" > $TMP && mv $TMP "${docs}/risk-profiles.json"
 
   ### Cases
   # convert openapi 3 yaml to swagger 2 json

--- a/source/api/api-descriptions/user_risk_profile_patch.rmd
+++ b/source/api/api-descriptions/user_risk_profile_patch.rmd
@@ -1,8 +1,10 @@
 HTTP PATCH methods support partially updating a resource. To accomplish this, each request must specify exactly which
 fields are to be updated. This is commonly called the "field mask", and in this endpoint is provided by the `paths` query
-param. Any keys in the request body that aren't in the field mask paths are ignored. This enables one to request an
+param. Any keys in the request body that aren't in the field mask paths are ignored.
+
+This enables a user to request an
 object via a GET request, change the desired fields, then send back the same full object, without the possibility of
-overwriting some other request that had happened in the meantime that had modified a different, unrelated field.
+overwriting some other update request on that object that had happened in the meantime and modified a different, unrelated field.
 
 For example:
 

--- a/swagger_template.json
+++ b/swagger_template.json
@@ -22,7 +22,7 @@
         {"name": "Rules", "description": {"$ref": "./api-descriptions/rules.rmd"}},
         {"name": "Trusted Activities", "description": {"$ref": "./api-descriptions/trusted_activities.rmd"}},
         {"name": "Users", "description": {"$ref": "./api-descriptions/user.rmd"}},
-        {"name": "User Risk Profiles", "description": {"$ref": "./api-descriptions/user_risk_profiles.rmd"}},
+        {"name": "Risk Profiles", "description": {"$ref": "./api-descriptions/user_risk_profiles.rmd"}},
         {"name": "Watchlists", "description": {"$ref": "./api-descriptions/watchlists.rmd"}}
     ],
     "produces": ["application/json"],


### PR DESCRIPTION
At some point we should check if all docs are updated to OpenAPI 3 so we can stop reformatting everything to swagger 2 (we just need them all on the same formatting)